### PR TITLE
Capturing buffer length reduces to 2

### DIFF
--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -775,7 +775,7 @@ void UsbCam::init_mmap(void)
 
   CLEAR(req);
 
-  req.count = 4;
+  req.count = 2;
   req.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
   req.memory = V4L2_MEMORY_MMAP;
 

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -60,17 +60,16 @@ namespace usb_cam {
 
 void monotonicToRealTime(const timespec& monotonic_time, timespec& real_time)
 {
-  struct timespec real_sample1, real_sample2, monotonic_sample;
+  struct timespec real_sample, monotonic_sample;
 
   // TODO(lucasw) Disable interrupts here?
   // otherwise what if there is a delay/interruption between sampling the times?
-  clock_gettime(CLOCK_REALTIME, &real_sample1);
   clock_gettime(CLOCK_MONOTONIC, &monotonic_sample);
-  clock_gettime(CLOCK_REALTIME, &real_sample2);
+  clock_gettime(CLOCK_REALTIME, &real_sample);
 
   timespec time_diff;
-  time_diff.tv_sec = real_sample2.tv_sec - monotonic_sample.tv_sec;
-  time_diff.tv_nsec = real_sample2.tv_nsec - monotonic_sample.tv_nsec;
+  time_diff.tv_sec = real_sample.tv_sec - monotonic_sample.tv_sec;
+  time_diff.tv_nsec = real_sample.tv_nsec - monotonic_sample.tv_nsec;
 
   // This isn't available outside of the kernel
   // real_time = timespec_add(monotonic_time, time_diff);

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -571,6 +571,13 @@ int UsbCam::read_frame()
         }
       }
 
+      switch (buf.flags & V4L2_BUF_FLAG_TIMESTAMP_MASK) {
+      case V4L2_BUF_FLAG_TIMESTAMP_COPY:
+      case V4L2_BUF_FLAG_TIMESTAMP_UNKNOWN:
+          ROS_ERROR("Unexpected v4l buffer timestamp mask. Should be monotonic.");
+          exit(EXIT_FAILURE);
+      }
+
       // need to get buf time here otherwise process_image will zero it
       TIMEVAL_TO_TIMESPEC(&buf.timestamp, &buf_time);
       monotonicToRealTime(buf_time, real_time);

--- a/src/usb_cam.cpp
+++ b/src/usb_cam.cpp
@@ -524,6 +524,9 @@ int UsbCam::read_frame()
 
   switch (io_)
   {
+    case IO_METHOD_UNKNOWN:
+      errno_exit("read frame: IO_METHOD_UNKNOWN");
+      break;
     case IO_METHOD_READ:
       len = read(fd_, buffers_[0].start, buffers_[0].length);
       if (len == -1)
@@ -652,6 +655,9 @@ void UsbCam::stop_capturing(void)
 
   switch (io_)
   {
+    case IO_METHOD_UNKNOWN:
+      errno_exit("stop capturing: IO_METHOD_UNKNOWN");
+      break;
     case IO_METHOD_READ:
       /* Nothing to do. */
       break;
@@ -677,6 +683,9 @@ void UsbCam::start_capturing(void)
 
   switch (io_)
   {
+    case IO_METHOD_UNKNOWN:
+      errno_exit("stop capturing: IO_METHOD_UNKNOWN");
+      break;
     case IO_METHOD_READ:
       /* Nothing to do. */
       break;
@@ -736,6 +745,9 @@ void UsbCam::uninit_device(void)
 
   switch (io_)
   {
+    case IO_METHOD_UNKNOWN:
+      errno_exit("uninit device: IO_METHOD_UNKNOWN");
+      break;
     case IO_METHOD_READ:
       free(buffers_[0].start);
       break;
@@ -913,6 +925,9 @@ void UsbCam::init_device(int image_width, int image_height, int framerate)
 
   switch (io_)
   {
+    case IO_METHOD_UNKNOWN:
+      errno_exit("init device: IO_METHOD_UNKNOWN");
+      break;
     case IO_METHOD_READ:
       if (!(cap.capabilities & V4L2_CAP_READWRITE))
       {
@@ -1009,6 +1024,9 @@ void UsbCam::init_device(int image_width, int image_height, int framerate)
 
   switch (io_)
   {
+    case IO_METHOD_UNKNOWN:
+      errno_exit("init device: IO_METHOD_UNKNOWN");
+      break;
     case IO_METHOD_READ:
       init_read(fmt.fmt.pix.sizeimage);
       break;


### PR DESCRIPTION
In order to get always only a most fresh frame. In case of buffer length 2 we have 1 place for currently capturing frame and 1 for already captured.

Also, I've fixed warnings with missing `case IO_METHOD_UNKNOWN`, add extra check for timestamp type mask and rid of an extra time sample.